### PR TITLE
Fix opacity toggle overlay

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -464,10 +464,7 @@ body.opacity-mode .opacity-overlay {
     visibility: visible;
 }
 
-/* Dark background for opacity mode */
-body.opacity-mode {
-    background-color: #000;
-}
+
 
 /* Hide background patterns */
 body.opacity-mode .header::before,


### PR DESCRIPTION
## Summary
- remove black background from `opacity-mode` so hero elements show through overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845b812edd0833395fe6263a7d0bb87